### PR TITLE
Refactor common data

### DIFF
--- a/colourlovers_api/data_containers.py
+++ b/colourlovers_api/data_containers.py
@@ -53,7 +53,7 @@ class HSV(object):
 class DrawColors(object):
     def __init__(self, rgb_colors):
         self.rgb_colors = rgb_colors
-        self.num_colors = len(self.colors)
+        self.num_colors = len(self.rgb_colors)
 
     def draw(self, tile_size=24, offset=8):
         # Allows the visualization of colors

--- a/colourlovers_api/data_containers.py
+++ b/colourlovers_api/data_containers.py
@@ -23,6 +23,9 @@ class CommonData(object):
 
 
 class HexConverter(CommonData):
+    def __init__(self, json_data):
+        self.colors = json_data["colors"]
+
     def hex_to_rgb(self):
         # Converts color in hex to RGB. Returns list of tuples where the channel order is (R,G,B)
         return [tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4)) for hex_color in self.colors]
@@ -47,67 +50,47 @@ class HSV(object):
         self.value = hsv["value"]
         self.hsv = (self.hue, self.saturation, self.value)
 
-
-# Particular classes for each type of object
-class Palette(HexConverter):
-    def __init__(self, json_data):
-        HexConverter.__init__(self, json_data)
-        try:
-            self.color_widths = json_data["colorWidths"]
-        except:
-            pass
-
-        self.colors = json_data["colors"]
+class DrawColors(object):
+    def __init__(self, rgb_colors):
+        self.rgb_colors = rgb_colors
         self.num_colors = len(self.colors)
 
     def draw(self, tile_size=24, offset=8):
-        # Allows the visualization of the palette
+        # Allows the visualization of colors
         im = Image.new("RGB", ((offset+tile_size+offset)*self.num_colors, tile_size), "black")
         draw = ImageDraw.Draw(im)
-        rgb_colors = self.hex_to_rgb()
         for i in range(self.num_colors):
             draw.rectangle(
                 (((offset+tile_size)*i, 0), ((offset+tile_size)*(i+1)-offset, tile_size)),
-                fill=rgb_colors[i]
+                fill=self.rgb_colors[i]
             )
         im.show()
 
 
-class Color(CommonData):
+# Particular classes for each type of object
+class Palette(HexConverter, DrawColors):
+    def __init__(self, json_data):
+        HexConverter.__init__(self, json_data)
+        DrawColors.__init__(self, self.hex_to_rgb())
+        try:
+            self.color_widths = json_data["colorWidths"]
+        except KeyError:
+            pass
+
+
+class Color(CommonData, DrawColors):
     def __init__(self, json_data):
         CommonData.__init__(self, json_data)
         self.hex = json_data["hex"]
         self.RGB = RGB(json_data["rgb"])
         self.HSV = HSV(json_data["hsv"])
-
-    def draw(self, tile_size=24, offset=8):
-        # Allows visualization of the color
-        im = Image.new("RGB", ((offset+tile_size+offset), tile_size), "black")
-        draw = ImageDraw.Draw(im)
-        draw.rectangle(
-            (((offset+tile_size), 0), (tile_size, tile_size)),
-            fill=self.RGB.rgb
-        )
-        im.show()
+        DrawColors.__init__(self, [self.RGB.rgb])
 
 
-class Pattern(HexConverter):
+class Pattern(HexConverter, DrawColors):
     def __init__(self, json_data):
         HexConverter.__init__(self, json_data)
-        self.colors = json_data["colors"]
-        self.num_colors = len(self.colors)
-
-    def draw(self, tile_size=24, offset=8):
-        # Allows the visualization of the palette
-        im = Image.new("RGB", ((offset+tile_size+offset)*self.num_colors, tile_size), "black")
-        draw = ImageDraw.Draw(im)
-        rgb_colors = self.hex_to_rgb()
-        for i in range(self.num_colors):
-            draw.rectangle(
-                (((offset+tile_size)*i, 0), ((offset+tile_size)*(i+1)-offset, tile_size)),
-                fill=rgb_colors[i]
-            )
-        im.show()
+        DrawColors.__init__(self, self.hex_to_rgb())
 
 
 class Lover(object):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

There were repeated methods in the classes used to store the data obtained from a query.

## Current behavior before PR

The `draw` method was repeated amongst `Color`, `Palette` and `Pattern` classes.

## Desired behavior after PR is merged

 `Color`, `Palette` and `Pattern` classes now inherit from a new class which provides the `draw` method.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
