### PR TITLE
Fix import

### DIFF
--- a/colourlovers/api.py
+++ b/colourlovers/api.py
@@ -2,7 +2,7 @@
 import collections
 import json
 from urllib.request import Request, urlopen, URLError
-from colourlovers_api.data_containers import *
+from colourlovers.data_containers import *
 
 
 # TODO


### PR DESCRIPTION
## Current behavior before PR

Due to #19 the `data_containers` import was broken

## Desired behavior after PR is merged

`data_containers` can be imported again

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
