### PR TITLE
Fix data storage from query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,5 +25,5 @@ Alpha version (unreleased)
 **Fixed**
 
 - #14 When making a query the type of raw-data is checked. In case it is not a boolean value an exception is raised
-
+- #23 Fix data loss when creating Python container objects
 

--- a/colourlovers/data_containers.py
+++ b/colourlovers/data_containers.py
@@ -24,6 +24,7 @@ class CommonData(object):
 
 class HexConverter(CommonData):
     def __init__(self, json_data):
+        CommonData.__init__(self, json_data)
         self.colors = json_data["colors"]
 
     def hex_to_rgb(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `HexConverter` class wasn't properly calling the `__init__` method from  `CommonData` and this resulted in a loss of information. 

## Current behavior before PR

Data obtained from the query was being lost in the data holder classes.

## Desired behavior after PR is merged

All the data is properly stored and can be accessed.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
