### PR TITLE
Avoid removing `valid_keyword` from `kwargs` after clearing `kwargs`

### DIFF
--- a/colourlovers/clapi.py
+++ b/colourlovers/clapi.py
@@ -410,20 +410,20 @@ class ColourLovers(object):
             # then ignore the rest of arguments since they are not allowed
             if self.__API_EXCLUSIVE_REQUEST == kwargs[valid_keyword] or search_type == self.__API_STATS:
                 kwargs = {}
-            del kwargs[valid_keyword]
+            else:
+                del kwargs[valid_keyword]
 
         return processed_request(kwargs=kwargs, optional_request=optional_request_term)
 
     def __validate_optional_request(self, search_type, request_value):
-    		"""
-
-    		:param search_type:
-    		:param request_value:
-    		:return:
-    		"""
-            request = set({request_value})
-            if bool(request.intersection(self.__API_REQUEST_TYPE[search_type])):
-                return True
-            elif search_type in self.__ALLOW_FLEXIBLE_REQUEST:
-                return True
-            return False
+        """
+        :param search_type:
+        :param request_value:
+        :return:
+        """
+        request = set({request_value})
+        if bool(request.intersection(self.__API_REQUEST_TYPE[search_type])):
+            return True
+        elif search_type in self.__ALLOW_FLEXIBLE_REQUEST:
+            return True
+        return False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the 'random' search issue (#27). Also fix the bad indentation in `__validate_optional_request`.

## Current behavior before PR

`search_palettes(request="random")` errored out with a `KeyError` exception when executing `del kwargs[valid_keyword]` after `kwargs` was cleared.

## Desired behavior after PR is merged

`search_palettes(request="random")` returns a random palette without any `KeyError` exceptions ;)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
